### PR TITLE
Undefined variables for Id attribute namespace/prefix

### DIFF
--- a/src/XMLSecurityDSig.php
+++ b/src/XMLSecurityDSig.php
@@ -1148,8 +1148,8 @@ class XMLSecurityDSig
             $x509CertNode->SetAttribute("ValueType", "http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-x509-token-profile-1.0#X509v3");
 
             $id = "key-" . sha1(base64_decode($X509Cert));
-            if (! empty($key_id_prefix_ns)) {
-                $x509CertNode->SetAttributeNS($key_id_prefix_ns, $key_id_prefix.":".$key_id_name, $id);
+            if (! empty($key_id_ns)) {
+                $x509CertNode->SetAttributeNS($key_id_ns, $key_id_pfx.":".$key_id_name, $id);
             } else {
                 $x509CertNode->SetAttribute($key_id_name, $id);
             }


### PR DESCRIPTION
If an $options array was passed to the add509CertByReference function to assign a prefix to the Id attribute, the namespace/prefix values were not applied because they were referencing the wrong (undefined) variables.
